### PR TITLE
make .env for docker compose optional

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,8 @@ services:
         - https_proxy=$HTTPS_PROXY
     init: true
     env_file:
-     - .env
+      - path: .env
+        required: false
     ports:
       - "59829:8888"
     restart: always


### PR DESCRIPTION
# やったこと
- docker composeに使用する.envファイルを非必須にしました
  - 現状、プロキシ設定がない人には不要であるため