### PR TITLE
modify snpcaster notebook to adapt multiple extensions for art_fq

### DIFF
--- a/app/notebook/template/jp/SNPcaster.ipynb
+++ b/app/notebook/template/jp/SNPcaster.ipynb
@@ -86,13 +86,14 @@
     "# パラメータを設定\n",
     "####################################################\n",
     "list = \"list_art\"\n",
-    "\n",
+    "# FASTAファイルの拡張子(ドット付き)を入力\n",
+    "file_extension = \".fasta\"\n",
     "\n",
     "####################################################\n",
     "# Run art_fq_generator (変更不要)\n",
     "####################################################\n",
     "\n",
-    "!bash art_fq_generator.sh $list\n",
+    "!bash art_fq_generator.sh $list $file_extension\n",
     "!echo 'Complete!'"
    ]
   },


### PR DESCRIPTION
# やったこと
- rt_fq_generator.shの引数で入力ファイルの拡張子を指定可能にしました。