### PR TITLE
fix cluster snp logic

### DIFF
--- a/app/src/snpcaster/snp_conversion.pl
+++ b/app/src/snpcaster/snp_conversion.pl
@@ -142,7 +142,7 @@ sub is_cluster_snp {
     my ($cur_snp_hash_ref, $next_snp_hash_ref) = @_;
     my $cur_pos = $cur_snp_hash_ref->{position};
     my $next_pos = $next_snp_hash_ref->{position};
-    if ($next_pos - $cur_pos >= $gap) {
+    if ($next_pos - $cur_pos > $gap) {
         return 0;
     }
     my $cur_ref = $cur_snp_hash_ref->{ref};


### PR DESCRIPTION
# やったこと
- クラスターSNP検出で指定したGAP閾値「未満」の差がある場合にクラスターSNPと認識していた→GAP値「以下」を認識するように修正
  - 例: GAP閾値=10の時、位置が1と11(差:10)のSNPは修正前だとクラスターSNP**ではない**と判定
  -  修正後、クラスターSNP**である**と判定される。
  - 差：11の場合(位置が1と12)はどちらのケースもクラスターSNP**ではない**と判定される