### PR TITLE
READMEからマニュアルへのリンク切れ修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ SNPcaster is an analysis pipeline that performs the following processes on short
 
 ## Installation
 Please follow the steps below to start SNPcaster.<br>
-Detailed installation instructions and usage are described in the [manual](/doc/manual/SNPcaster_manual_Japanese.pdf). Please refer to it if you have any questions.
+Detailed installation instructions and usage are described in the [manual](/doc/manual/SNPcaster_manual_Japanese.pdf). Please refer to it if you have any questions.<br>
+*Note: Please check the [Manual Folder](https://github.com/leech-rr/SNPcaster/tree/main/doc/manual), if the manual link is broken.*
 
 ### Downloading the Source Code
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ SNPcaster is an analysis pipeline that performs the following processes on short
 
 ## Installation
 Please follow the steps below to start SNPcaster.<br>
-Detailed installation instructions and usage are described in the [manual](/doc/manual/2025-05-28_SNPcaster_manual_Japanese.pdf). Please refer to it if you have any questions.
+Detailed installation instructions and usage are described in the [manual](/doc/manual/SNPcaster_manual_Japanese.pdf). Please refer to it if you have any questions.
 
 ### Downloading the Source Code
 
@@ -31,7 +31,7 @@ cd SNPcaster
 docker compose up -d --build
 ```
 The initial startup may take from 1 to several hours.<br>
-For details on Docker installation and other information, please refer to the [manual](/doc/manual/2025-05-20_SNPcaster_Installation_Operation_Manual.pdf).
+For details on Docker installation and other information, please refer to the [manual](/doc/manual/SNPcaster_manual_Japanese.pdf).
 
 ### Accessing Jupyter Notebook
 Once started, you can access the Jupyter notebook by visiting [http://localhost:59829](http://localhost:59829) in your preferred browser.

--- a/README_JP.md
+++ b/README_JP.md
@@ -8,7 +8,7 @@ SNPcasterは次世代シーケンサーから得たショートリードデー�
 
 ## インストール方法
 以下の手順でSNPcasterを起動してください。<br>
-詳細なインストール手順や使い方は[マニュアル](/doc/manual/2025-05-20_SNPcaster_インストール_操作マニュアル.pdf)に記載しています。ご不明点がある場合はそちらをご覧ください。
+詳細なインストール手順や使い方は[マニュアル](/doc/manual/SNPcaster_manual_Japanese.pdf)に記載しています。ご不明点がある場合はそちらをご覧ください。
 
 ### ソースコードのダウンロード
 
@@ -31,7 +31,7 @@ cd SNPcaster
 docker compose up -d --build
 ```
 初回起動は、1～数時間かかります。<br>
-Dockerのインストール方法などの詳細は、[マニュアル](/doc/manual/2025-05-28_SNPcaster_manual_Japanese.pdf)に記載してあるのでご覧ください。
+Dockerのインストール方法などの詳細は、[マニュアル](/doc/manual/SNPcaster_manual_Japanese.pdf)に記載してあるのでご覧ください。
 
 ### Jupyter notebookへのアクセス
 起動後、お好きなブラウザで[http://localhost:59829](http://localhost:59829)にアクセスすると、Jupyter notebookにアクセス可能です。

--- a/README_JP.md
+++ b/README_JP.md
@@ -8,7 +8,8 @@ SNPcasterは次世代シーケンサーから得たショートリードデー�
 
 ## インストール方法
 以下の手順でSNPcasterを起動してください。<br>
-詳細なインストール手順や使い方は[マニュアル](/doc/manual/SNPcaster_manual_Japanese.pdf)に記載しています。ご不明点がある場合はそちらをご覧ください。
+詳細なインストール手順や使い方は[マニュアル](/doc/manual/SNPcaster_manual_Japanese.pdf)に記載しています。ご不明点がある場合はそちらをご覧ください。<br>
+*※マニュアルがリンク切れしている場合、[マニュアルフォルダ](https://github.com/leech-rr/SNPcaster/tree/main/doc/manual)からご確認ください。*
 
 ### ソースコードのダウンロード
 


### PR DESCRIPTION
# やったこと
- README(英語/日本語)からマニュアルのリンク切れが起きている問題を修正
  - マニュアルのファイル名から年月日を除き、**SNPcaster_manual_Japanese.pdf**に固定化